### PR TITLE
Fix two sorting problems in UniDataTable

### DIFF
--- a/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
+++ b/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
@@ -160,14 +160,8 @@ namespace Starcounter.Uniform.ViewModels
             /// </summary>
             public string Sort
             {
-                get
-                {
-                    return _sortValue;
-                }
-                set
-                {
-                    _sortValue = string.IsNullOrWhiteSpace(value) ? null : value;
-                }
+                get => _sortValue;
+                set => _sortValue = string.IsNullOrWhiteSpace(value) ? null : value;
             }
 
             public void Handle(Input.Filter action)

--- a/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
+++ b/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
@@ -145,8 +145,29 @@ namespace Starcounter.Uniform.ViewModels
         [UniDataTable_json.Columns]
         public partial class ColumnsViewModel : Json, IBound<DataTableColumn>
         {
+            private string _sortValue = null;
+
             public IFilteredDataProvider<Json> DataProvider { get; set; }
             public Action LoadRowsFromFirstPage { get; set; }
+
+            /// <summary>
+            /// Empty string is also a "value" on the client side, which results into invalid HTML attribute:
+            /// <uni-data-table-sorter direction>
+            /// While only
+            /// <uni-data-table-sorter direction="asc"> or <uni-data-table-sorter direction="desc">
+            /// Are valid.
+            /// </summary>
+            public string Sort
+            {
+                get
+                {
+                    return _sortValue;
+                }
+                set
+                {
+                    _sortValue = string.IsNullOrWhiteSpace(value) ? null : value;
+                }
+            }
 
             public void Handle(Input.Filter action)
             {

--- a/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
+++ b/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
@@ -151,11 +151,12 @@ namespace Starcounter.Uniform.ViewModels
             public Action LoadRowsFromFirstPage { get; set; }
 
             /// <summary>
-            /// Empty string is also a "value" on the client side, which results into invalid HTML attribute:
-            /// <uni-data-table-sorter direction>
-            /// While only
-            /// <uni-data-table-sorter direction="asc"> or <uni-data-table-sorter direction="desc">
-            /// Are valid.
+            /// The <see cref="string.Empty"/> value is replaced with NULL, 
+            /// because empty string is also a "value" on the client side, which results into invalid HTML attribute:
+            /// &lt;uni-data-table-sorter direction>
+            /// while only
+            /// &lt;uni-data-table-sorter direction="asc"> or &lt;uni-data-table-sorter direction="desc">
+            /// are valid.
             /// </summary>
             public string Sort
             {


### PR DESCRIPTION
- [UniDataTable view-model has default Sort values as an empty string](https://github.com/Starcounter/Starcounter.Uniform/issues/25).
- Fix column click behavior, when `Sort$` value set to `null`, previously, it was treated as `desc`.