### PR TITLE
Don't reevaluate query on dirty check just to get total rows

### DIFF
--- a/Starcounter.Uniform/Properties/AssemblyInfo.cs
+++ b/Starcounter.Uniform/Properties/AssemblyInfo.cs
@@ -32,8 +32,8 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.5.0")]
-[assembly: AssemblyFileVersion("2.5.0")]
+[assembly: AssemblyVersion("2.5.1")]
+[assembly: AssemblyFileVersion("2.5.1")]
 
 // Assures the current assembly has a reference to the Starcounter
 // assembly. A reference to Starcounter is currently required for

--- a/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
+++ b/Starcounter.Uniform/ViewModels/UniDataTable.json.cs
@@ -24,6 +24,7 @@ namespace Starcounter.Uniform.ViewModels
             Pagination.DataProvider = dataProvider;
             Pagination.LoadRows = LoadRows;
             Pagination.LoadRowsFromFirstPage = LoadRowsFromFirstPage;
+            Pagination.GetTotalRows = () => (int)TotalRows;
 
             this.DataProvider.PaginationConfiguration = new PaginationConfiguration(initialPageSize, initialPageIndex);
             this.DataProvider.FilterOrderConfiguration = new FilterOrderConfiguration();
@@ -114,10 +115,11 @@ namespace Starcounter.Uniform.ViewModels
             public IFilteredDataProvider<Json> DataProvider { get; set; }
             public Action LoadRows { get; set; }
             public Action LoadRowsFromFirstPage { get; set; }
+            public Func<int> GetTotalRows { get; set; }
 
             public int PageSize => DataProvider?.PaginationConfiguration.PageSize ?? 0;
 
-            public int PagesCount => (DataProvider?.TotalRows + DataProvider?.PaginationConfiguration.PageSize - 1) /
+            public int PagesCount => (GetTotalRows() + DataProvider?.PaginationConfiguration.PageSize - 1) /
                                      DataProvider?.PaginationConfiguration.PageSize ?? 0;
 
             public void Handle(Input.CurrentPageIndex action)


### PR DESCRIPTION
Table contents is only reloaded when you call `LoadRows()`, but the entire query is nevertheless evaluated on every dirty check to compute total rows for pagination. So let's stop doing that.